### PR TITLE
Catalog.Xaml: Format strings with plural count

### DIFF
--- a/Vernacular.Catalog/Vernacular.Xaml/Catalog.cs
+++ b/Vernacular.Catalog/Vernacular.Xaml/Catalog.cs
@@ -154,6 +154,7 @@ namespace Vernacular.Xaml
                 : Vernacular.Catalog.GetPluralString (message, plural_message, count);
 
             localized = ModifyString (localized, modifier);
+            localized = Format(localized, count);
             var property = FindMessageProperty (framework_element);
             if (property != null) {
                 framework_element.SetValue (property, localized);


### PR DESCRIPTION
Hey Aaron,

could you consider merging this please ? It calls Format just before displaying, so my strings can be like "{0} items selected".

Stephane
