### PR TITLE
Analyzer: make hunspell bindings works on Windows

### DIFF
--- a/Vernacular.Tool/Vernacular.Analyzers/Hunspell.cs
+++ b/Vernacular.Tool/Vernacular.Analyzers/Hunspell.cs
@@ -37,15 +37,31 @@ namespace Vernacular.Analyzers
     // as well (UTF-8).
     public class Hunspell
     {
+#if WIN32
+        private const string LIBHUNSPELL = "libhunspell";
+#else
         private const string LIBHUNSPELL = "libhunspell-1.2";
+#endif
 
+#if WIN32
+        [DllImport (LIBHUNSPELL, CallingConvention = CallingConvention.Cdecl)]
+#else
         [DllImport (LIBHUNSPELL)]
+#endif
         private static extern IntPtr Hunspell_create (string affpath, string dicpath);
 
+#if WIN32
+        [DllImport (LIBHUNSPELL, CallingConvention = CallingConvention.Cdecl)]
+#else
         [DllImport (LIBHUNSPELL)]
+#endif
         private static extern int Hunspell_spell (IntPtr handle, string word);
 
+#if WIN32
+        [DllImport (LIBHUNSPELL, CallingConvention = CallingConvention.Cdecl)]
+#else
         [DllImport (LIBHUNSPELL)]
+#endif
         private static extern int Hunspell_add (IntPtr handle, string word);
 
         private IntPtr handle;


### PR DESCRIPTION
Depending on whether you find it useful or not, I could as well include a libhunspell.dll, prebuild for windows, in the project
