### PR TITLE
Entry: new resx-template option

### DIFF
--- a/Vernacular.Tool/Vernacular.Generators/ResourceString.cs
+++ b/Vernacular.Tool/Vernacular.Generators/ResourceString.cs
@@ -38,6 +38,8 @@ namespace Vernacular.Tool
         public string Untranslated { get; set; }
         public string Translated { get; set; }
 
+        public static bool UseNamesAsIds { get; set; }
+
         public string SortKey {
             get {
                 // We want to chop off the Vernacular_P0_M_ style
@@ -46,6 +48,8 @@ namespace Vernacular.Tool
             }
         }
 
+
+        
         public static IEnumerable<ResourceString> Generate (ResourceIdType resourceIdType, LocalizedString localizedString)
         {
             string [] translated;
@@ -65,13 +69,16 @@ namespace Vernacular.Tool
                     continue;
                 }
 
-                yield return new ResourceString {
-                    Id = Catalog.GetResourceId (resourceIdType,
-                        localizedString.Context, localizedString.UntranslatedSingularValue,
-                        localizedString.Gender, i),
-                    Untranslated = localizedString.UntranslatedSingularValue,
-                    Translated = translated [i]
-                };
+                yield return new ResourceString
+                                 {
+                                     Id = UseNamesAsIds
+                                             ? localizedString.Name
+                                             : Catalog.GetResourceId(resourceIdType, localizedString.Context,
+                                                                     localizedString.UntranslatedSingularValue,
+                                                                     localizedString.Gender, i),
+                                     Untranslated = localizedString.UntranslatedSingularValue,
+                                     Translated = translated[i]
+                                 };
             }
         }
     }

--- a/Vernacular.Tool/Vernacular.Tool/Entry.cs
+++ b/Vernacular.Tool/Vernacular.Tool/Entry.cs
@@ -27,7 +27,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
-
+using System.Linq;
 using Mono.Options;
 
 using Vernacular.Parsers;
@@ -49,6 +49,7 @@ namespace Vernacular.Tool
             string android_input_strings_xml = null;
             string android_output_strings_xml = null;
             string analyer_config_path = null;
+            string resx_template_path = null;
             LocalizationMetadata metadata = null;
             bool generate_pot = false;
             bool exclude_po_header = false;
@@ -80,6 +81,7 @@ namespace Vernacular.Tool
                     "for preserving hand-maintained string resources", v => android_input_strings_xml = v },
                 { "android-output-strings-xml=", "Output file of localized Android Strings.xml " +
                     "for preserving hand-maintained string resources", v => android_output_strings_xml = v },
+                { "resx-template=", "Use Ids from the resx template", v => resx_template_path = v},
                 { "pot", v => generate_pot = v != null },
                 { "exclude-po-header", v => exclude_po_header = v != null },
                 { "l|log", "Display logging", v => log = v != null },
@@ -145,6 +147,14 @@ namespace Vernacular.Tool
 
                     return 0;
                 }
+
+                if (resx_template_path != null && !(generator is ResxGenerator)) {
+                    throw new OptionException ("resx-template require the generator to be resx", "resx-template");
+                }
+
+                if(resx_template_path != null) {
+                    ResourceString.UseNamesAsIds = true;
+                }
             } catch (OptionException e) {
                 Console.WriteLine ("vernacular: {0}", e.Message);
                 Console.WriteLine ("Try `vernacular --help` for more information.");
@@ -197,10 +207,28 @@ namespace Vernacular.Tool
                 generator.Add (metadata);
             }
 
+            List<ILocalizationUnit> id_replacements = null;
+            if (resx_template_path != null) {
+                var resx_template_parser = new ResxParser ();
+                resx_template_parser.Add (resx_template_path);
+                id_replacements = resx_template_parser.Parse().ToList();
+            }
+
             foreach (var localization_unit in parser.Parse ()) {
+                var localized_string = localization_unit as LocalizedString;
+                if (id_replacements != null && localized_string!=null)
+                {
+                    var replacement = (from lu in id_replacements
+                                       where
+                                           (lu as LocalizedString).UntranslatedSingularValue ==
+                                           localized_string.UntranslatedSingularValue
+                                       select lu).FirstOrDefault();
+                    if (replacement == null)
+                        continue;
+                    localized_string.Name = (replacement as LocalizedString).Name;                    
+                }
                 generator.Add (localization_unit);
 
-                var localized_string = localization_unit as LocalizedString;
                 if (analyzer != null) {
                     analyzer.Add (localized_string);
                 }


### PR DESCRIPTION
Specifying the resx-template option, along with the -g resx generator,
allows to create files, from translated .po's for aspx consumption.

Let's say you have a login.aspx.resx file used by asp.NET globalization.
You first prepare a .pot as translation template:

> vernacular -i login.apsx.resx -g po --pot -o login.pot

At some point in time later, you get a fully translated login page in,
say, French, named fr.po. If we convert it at this point back into a resx,
we'll have vernacular generated ids, unsuitable for asp.NET. But we can
use our original file as template, to generate the right ids:

> vernacular -i fr.po --resx-template login.aspx.resx -g resx -o
>  fr.aspx.resx

That's it.
