### PR TITLE
PoGenerator: Fix line termination

### DIFF
--- a/Vernacular.Potato/Vernacular.Potato/Message.cs
+++ b/Vernacular.Potato/Vernacular.Potato/Message.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using System.Text;
 using System.Collections.Generic;
 
@@ -131,13 +132,16 @@ namespace Vernacular.Potato
             builder.Append (' ');
 
             var lines = Value.Split ('\n');
-            if (lines.Length > 1) {
+            if (lines.Length > 1)
+            {
+                var skip_last_linetermination = !String.IsNullOrEmpty(lines.Last());
                 builder.Append ("\"\"\n");
-                foreach (var line in lines) {
-                    if (!String.IsNullOrEmpty (line)) {
+                for (var i = 0; i < lines.Length;i++ ) {
+                    if (!String.IsNullOrEmpty (lines[i])) {
                         builder.Append ('"');
-                        builder.Append (Escape (line));
-                        builder.Append ("\\n\"");
+                        builder.Append (Escape (lines[i]));
+                        if (i != lines.Length -1 || !skip_last_linetermination)
+                            builder.Append ("\\n\"");
                         builder.Append ('\n');
                     }
                 }


### PR DESCRIPTION
there was a bug in the PoGenerator adding a \n at the end of
the last part of a multiline message, even if the original message
did not contained one. This should fix it.
