### PR TITLE
Fixes NullReferenceException when using Vernacular on Android.

### DIFF
--- a/Vernacular.Catalog/Vernacular/AndroidCatalog.cs
+++ b/Vernacular.Catalog/Vernacular/AndroidCatalog.cs
@@ -54,7 +54,7 @@ namespace Vernacular
         public override string CoreGetString (string message)
         {
             int resource_id;
-            if (GetResource (out resource_id, message)) {
+            if (GetResource (out resource_id, null, message)) {
                 return GetString (resource_id);
             }
 
@@ -64,7 +64,7 @@ namespace Vernacular
         public override string CoreGetPluralString (string singularMessage, string pluralMessage, int n)
         {
             int resource_id;
-            if (GetResource (out resource_id, singularMessage, pluralCount: n)) {
+            if (GetResource (out resource_id, null, singularMessage, pluralCount: n)) {
                 return GetString (resource_id);
             }
 
@@ -75,7 +75,7 @@ namespace Vernacular
         {
             int resource_id;
             var message = gender == LanguageGender.Feminine ? feminineMessage : masculineMessage;
-            if (GetResource (out resource_id, message, gender: gender)) {
+            if (GetResource (out resource_id, null, message, gender: gender)) {
                 return GetString (resource_id);
             }
 
@@ -89,7 +89,7 @@ namespace Vernacular
         {
             int resource_id;
             var message = gender == LanguageGender.Feminine ? singularFeminineMessage : singularMasculineMessage;
-            if (GetResource (out resource_id, message, gender: gender, pluralCount: n)) {
+            if (GetResource (out resource_id, null, message, gender: gender, pluralCount: n)) {
                 return GetString (resource_id);
             }
 

--- a/Vernacular.Catalog/Vernacular/FieldReflectionResourceCatalog.cs
+++ b/Vernacular.Catalog/Vernacular/FieldReflectionResourceCatalog.cs
@@ -72,7 +72,7 @@ namespace Vernacular
             reflection_type = reflectionType;
         }
 
-        protected bool GetResource (out T resource, string context, string message = null,
+        protected bool GetResource (out T resource, string context, string message,
             LanguageGender gender = LanguageGender.Neutral, int pluralCount = 1)
         {
             var cached_string = new CachedString {


### PR DESCRIPTION
 AndroidCatalog calls to it's base class's GetResource has mismatched parameters because it fails to pass in a value for the required context parameter. The iOS counterpart ResourceCatalog passes in null's for the context. Catalog.GetString calls AndroidCatalog.CoreGetString() which calls FieldReflectionResourceCatalog.GetResource which requires a string context. Since the message gets passes in the place of the context, and the default null value (now required, not sure why it shouldn't be) gets set as the Message for the CachedString object that is created. Then, in CachedString's GetHashCode(), Message.GetHashCode() throws the NullReferenceException. This is now avoided by passing null in for the context and placing the message value in the proper signature index, and by ensuring that a value for the message is passed in.
