### PR TITLE
Correctly generate strings with newlines for Android

### DIFF
--- a/Vernacular.Tool/Vernacular.Generators/AndroidGenerator.cs
+++ b/Vernacular.Tool/Vernacular.Generators/AndroidGenerator.cs
@@ -111,6 +111,8 @@ namespace Vernacular.Generators
                 value = value.Replace("...", "&#8230;");
             if (value.Contains("'"))
                 value = value.Replace("'", "\\'");
+            if (value.Contains("\n"))
+                value = value.Replace("\n", "\\n");
 
             return value;
         }


### PR DESCRIPTION
Newlines in string values should be replaced by "\n" on Android. Otherwise the newlines are just being ignored.