### PR TITLE
Make Catalog work with new Unified API, giving the correct default namespace.

### DIFF
--- a/Vernacular.Catalog/Vernacular.Catalog.csproj
+++ b/Vernacular.Catalog/Vernacular.Catalog.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{BEC7B55D-F922-446D-9BBF-12DB249C4CA4}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Vernacular.Catalog</RootNamespace>
+    <RootNamespace>Vernacular</RootNamespace>
     <AssemblyName>Vernacular.Catalog</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
Including the DLL file in projects building with Xamarin.iOS 8.6 will give an error that Vernacular namespace is missing. This will fix that.